### PR TITLE
Add skipUnsupportedRdfJs option to provenance rules

### DIFF
--- a/src/provenance.ts
+++ b/src/provenance.ts
@@ -56,6 +56,7 @@ export function inferProvenance(
         },
         {
             rdfjs: true,
+            skipUnsupportedRdfJs: true,
             onDerived: ({ quad }) => {
                 if (!quad) {
                     return

--- a/src/provenance.ts
+++ b/src/provenance.ts
@@ -56,6 +56,7 @@ export function inferProvenance(
         },
         {
             rdfjs: true,
+            // Sometimes we have `sh:path ( )` in our input. We need to skip such input as we cannot derive an OWL definition for that.
             skipUnsupportedRdfJs: true,
             onDerived: ({ quad }) => {
                 if (!quad) {


### PR DESCRIPTION
this helps when trying to derive complex shacl paths